### PR TITLE
Fix spelling of "CANCLED" to "CANCELED"

### DIFF
--- a/ShippingProAPICollection.NUnitTests/DHLTests.cs
+++ b/ShippingProAPICollection.NUnitTests/DHLTests.cs
@@ -173,7 +173,7 @@ namespace ShippingProAPICollection.NUnitTests
             foreach (var label in createResult)
             {
                 var cancelResult = (await shippingCollection.CancelLabel("DHL", label.CancelId));
-                Assert.That(cancelResult == ShippingCancelResult.CANCLED);
+                Assert.That(cancelResult == ShippingCancelResult.CANCELED);
             }
 
         }

--- a/ShippingProAPICollection.NUnitTests/DPDTests.cs
+++ b/ShippingProAPICollection.NUnitTests/DPDTests.cs
@@ -101,7 +101,7 @@ namespace ShippingProAPICollection.NUnitTests
             foreach (var label in createResult)
             {
                 var cancelResult = (await shippingCollection.CancelLabel("DPD", label.CancelId));
-                Assert.That(cancelResult == ShippingCancelResult.CANCLED);
+                Assert.That(cancelResult == ShippingCancelResult.CANCELED);
             }
 
         }

--- a/ShippingProAPICollection.NUnitTests/GLSTests.cs
+++ b/ShippingProAPICollection.NUnitTests/GLSTests.cs
@@ -197,7 +197,7 @@ namespace ShippingProAPICollection.NUnitTests
             foreach (var label in createResult)
             {
                 var cancelResult = (await shippingCollection.CancelLabel("GLS", label.CancelId));
-                Assert.That(cancelResult == ShippingCancelResult.CANCLED);
+                Assert.That(cancelResult == ShippingCancelResult.CANCELED);
             }
 
         }

--- a/ShippingProAPICollection.NUnitTests/TOFTests.cs
+++ b/ShippingProAPICollection.NUnitTests/TOFTests.cs
@@ -73,7 +73,7 @@ namespace ShippingProAPICollection.NUnitTests
 
                 var resultCancel = await shippingCollection.CancelLabel("TOF", result[0].CancelId);
 
-                Assert.That(resultCancel == Models.Entities.ShippingCancelResult.CANCLED);
+                Assert.That(resultCancel == Models.Entities.ShippingCancelResult.CANCELED);
             }
         }*/
 }

--- a/ShippingProAPICollection/Models/Entities/ShippingCancelResult.cs
+++ b/ShippingProAPICollection/Models/Entities/ShippingCancelResult.cs
@@ -6,7 +6,7 @@
         /// <summary>
         /// Label was successfully canceled
         /// </summary>
-        CANCLED,
+        CANCELED,
 
         /// <summary>
         /// Label already scanned or in use, cannot cancel label anymore

--- a/ShippingProAPICollection/Provider/DHL/DHLShipmentService.cs
+++ b/ShippingProAPICollection/Provider/DHL/DHLShipmentService.cs
@@ -170,7 +170,7 @@ namespace ShippingProAPICollection.Provider.DHL
                         throw new DHLException(ShippingErrorCode.CANNOT_CONVERT_RESPONSE, "Cannot convert reponse to object", new { payload = cancelId, respone = response.Content });
                     }
 
-                    return ShippingCancelResult.CANCLED;
+                    return ShippingCancelResult.CANCELED;
                 }
                 else if (response.StatusCode == System.Net.HttpStatusCode.BadRequest)
                 {

--- a/ShippingProAPICollection/Provider/DPD/DPDShipmentService.cs
+++ b/ShippingProAPICollection/Provider/DPD/DPDShipmentService.cs
@@ -93,7 +93,7 @@ namespace ShippingProAPICollection.Provider.DPD
         public async Task<ShippingCancelResult> CancelLabel(string cancelId, CancellationToken cancelToken = default)
         {
             // DPD is fucking crazy and we not need to cancel any labels :)
-            return ShippingCancelResult.CANCLED;
+            return ShippingCancelResult.CANCELED;
         }
 
         public async Task<ValidationReponse> ValidateLabel(RequestShipmentBase request, CancellationToken cancelToken)

--- a/ShippingProAPICollection/Provider/GLS/GLSShipmentService.cs
+++ b/ShippingProAPICollection/Provider/GLS/GLSShipmentService.cs
@@ -93,7 +93,7 @@ namespace ShippingProAPICollection.Provider.GLS
             {
                 case "CANCELLED":
                 case "CANCELLATION_PENDING":
-                    return ShippingCancelResult.CANCLED;
+                    return ShippingCancelResult.CANCELED;
                 case "SCANNED":
                     return ShippingCancelResult.ALREADY_IN_USE;
                 default:

--- a/ShippingProAPICollection/Provider/TRANSOFLEX/TOFShipmentService.cs
+++ b/ShippingProAPICollection/Provider/TRANSOFLEX/TOFShipmentService.cs
@@ -148,7 +148,7 @@ namespace ShippingProAPICollection.Provider.TRANSOFLEX
                 );
 
             HTTPReponseUtils.CheckHttpResponse<TOFException>(response.Content ?? "Unknow", cancelRequest, response);
-            return ShippingCancelResult.CANCLED;
+            return ShippingCancelResult.CANCELED;
         }
 
         public async Task<ValidationReponse> ValidateLabel(RequestShipmentBase request, CancellationToken cancelToken)


### PR DESCRIPTION
Corrected the spelling of "CANCLED" to "CANCELED" across multiple test files and service classes in the ShippingProAPICollection namespace. This change affects the DHL, DPD, GLS, and TOF shipment services, ensuring consistency in the naming of the shipping cancellation result.