### PR TITLE
Add custom sender address override for shipping labels

### DIFF
--- a/ShippingProAPICollection/Models/ShippingProAPIShipFromAddress.cs
+++ b/ShippingProAPICollection/Models/ShippingProAPIShipFromAddress.cs
@@ -1,9 +1,9 @@
-﻿
+
 using System.ComponentModel.DataAnnotations;
 
 namespace ShippingProAPICollection.Models
 {
-    public class ShippingProAPIAccountSettings
+    public class ShippingProAPIShipFromAddress
     {
         public required string Name { get; set; }
         public string? Name2 { get; set; }

--- a/ShippingProAPICollection/Provider/CustomProviderSettings.cs
+++ b/ShippingProAPICollection/Provider/CustomProviderSettings.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Memory;
 using ShippingProAPICollection.Models;
 using ShippingProAPICollection.Models.Entities;
 
@@ -7,6 +7,6 @@ namespace ShippingProAPICollection.Provider
     public abstract class CustomProviderSettings : ProviderSettings
     {
         public override ShippingProviderType ShippingProviderType => ShippingProviderType.CUSTOM;
-        public abstract IShippingProviderService CreateProviderService(ShippingProAPIAccountSettings accountSettings, IMemoryCache _cache);
+        public abstract IShippingProviderService CreateProviderService(ShippingProAPIShipFromAddress defaultShipFromAddress, IMemoryCache _cache);
     }
 }

--- a/ShippingProAPICollection/Provider/DHL/DHLShipmentService.cs
+++ b/ShippingProAPICollection/Provider/DHL/DHLShipmentService.cs
@@ -15,11 +15,11 @@ namespace ShippingProAPICollection.Provider.DHL
    {
 
       private DHLSettings providerSettings = null!;
-      private ShippingProAPIAccountSettings accountSettings = null!;
+      private ShippingProAPIShipFromAddress defaultShipFromAddress = null!;
 
-      public DHLShipmentService(ShippingProAPIAccountSettings accountSettings, DHLSettings providerSettings)
+      public DHLShipmentService(ShippingProAPIShipFromAddress defaultShipFromAddress, DHLSettings providerSettings)
       {
-         this.accountSettings = accountSettings;
+         this.defaultShipFromAddress = defaultShipFromAddress;
          this.providerSettings = providerSettings;
       }
 
@@ -224,19 +224,21 @@ namespace ShippingProAPICollection.Provider.DHL
       /// <returns></returns>
       private ShipmentOrderRequest CreateRequestModel(DHLShipmentRequestModel request)
       {
+         var from = request.ShipFromAddress ?? defaultShipFromAddress;
 
          // Build shipper infos
-         Shipper shipper = new Shipper()
+         var shipper = new Shipper()
          {
-            Name1 = accountSettings.Name,
-            Name2 = accountSettings.Name2,
-            Name3 = accountSettings.Name3,
-            AddressStreet = accountSettings.Street,
-            PostalCode = accountSettings.PostCode,
-            City = accountSettings.City,
-            Country = EnumUtils.ToEnum(ThreeLetterCountryCodeHelper.GetThreeLetterCountryCode(accountSettings.CountryIsoA2Code), Country.UNKNOWN),
-            ContactName = accountSettings.ContactName,
-            Email = accountSettings.Email,
+            Name1 = from.Name,
+            Name2 = string.IsNullOrWhiteSpace(from.Name2) ? null : from.Name2,
+            Name3 = string.IsNullOrWhiteSpace(from.Name3) ? null : from.Name3,
+            AddressStreet = from.Street,
+            PostalCode = from.PostCode,
+            City = from.City,
+            Country = EnumUtils.ToEnum(ThreeLetterCountryCodeHelper.GetThreeLetterCountryCode(from.CountryIsoA2Code), Country.UNKNOWN),
+            ContactName = from.ContactName,
+            Email = from.Email,
+            AddressHouse = null,
          };
 
          Consignee consignee = GetConsignee(request);

--- a/ShippingProAPICollection/Provider/DPD/DPDShipmentService.cs
+++ b/ShippingProAPICollection/Provider/DPD/DPDShipmentService.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable 1998
+#pragma warning disable 1998
 
 using DPDLoginService2_0;
 using DPDShipmentService4_4;
@@ -18,11 +18,11 @@ namespace ShippingProAPICollection.Provider.DPD
     {
         private readonly IMemoryCache _cache;
         private DPDSettings providerSettings = null!;
-        private ShippingProAPIAccountSettings accountSettings = null!;
+        private ShippingProAPIShipFromAddress defaultShipFromAddress = null!;
 
-        public DPDShipmentService(ShippingProAPIAccountSettings accountSettings, DPDSettings providerSettings, IMemoryCache cache)
+        public DPDShipmentService(ShippingProAPIShipFromAddress defaultShipFromAddress, DPDSettings providerSettings, IMemoryCache cache)
         {
-            this.accountSettings = accountSettings;
+            this.defaultShipFromAddress = defaultShipFromAddress;
             this.providerSettings = providerSettings;
             _cache = cache;
         }
@@ -151,17 +151,21 @@ namespace ShippingProAPICollection.Provider.DPD
                 product = EnumUtils.ToEnum<generalShipmentDataProduct>(request.ServiceProduct.ToString(), generalShipmentDataProduct.CL),
             };
 
+            var from = request.ShipFromAddress ?? defaultShipFromAddress;
+
             shipmentServiceData.generalShipmentData.sender = new addressWithType()
             {
                 addressType = addressWithTypeAddressType.COM,
-                name1 = accountSettings.Name,
-                street = accountSettings.Street,
-                country = accountSettings.CountryIsoA2Code,
-                zipCode = accountSettings.PostCode,
-                city = accountSettings.City,
-                contact = accountSettings.ContactName,
+                name1 = from.Name,
+                name2 = from.Name2,
+                email = from.Email,
+                phone = from.Phone,
+                street = from.Street,
+                country = from.CountryIsoA2Code,
+                zipCode = from.PostCode,
+                city = from.City,
+                contact = from.ContactName,
             };
-
 
             shipmentServiceData.generalShipmentData.recipient = new addressWithType()
             {

--- a/ShippingProAPICollection/Provider/GLS/GLSShipmentService.cs
+++ b/ShippingProAPICollection/Provider/GLS/GLSShipmentService.cs
@@ -1,4 +1,4 @@
-﻿using Newtonsoft.Json;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using RestSharp;
 using RestSharp.Authenticators;
@@ -20,11 +20,11 @@ namespace ShippingProAPICollection.Provider.GLS
     {
         private string apiContentType = "application/glsVersion1+json";
         private GLSSettings providerSettings = null!;
-        private ShippingProAPIAccountSettings accountSettings = null!;
+        private ShippingProAPIShipFromAddress defaultShipFromAddress = null!;
 
-        public GLSShipmentService(ShippingProAPIAccountSettings accountSettings, GLSSettings providerSettings)
+        public GLSShipmentService(ShippingProAPIShipFromAddress defaultShipFromAddress, GLSSettings providerSettings)
         {
-            this.accountSettings = accountSettings;
+            this.defaultShipFromAddress = defaultShipFromAddress;
             this.providerSettings = providerSettings;
         }
 
@@ -176,12 +176,14 @@ namespace ShippingProAPICollection.Provider.GLS
             // Api NotFound on current GLS api
             return 0;
 
+            var from = request.ShipFromAddress ?? defaultShipFromAddress;
+
             EstimatedDeliveryDaysAddress senderAddress = new EstimatedDeliveryDaysAddress()
             {
-                City = accountSettings.City,
-                CountryCode = accountSettings.CountryIsoA2Code,
-                ZIPCode = accountSettings.PostCode,
-                Street = accountSettings.Street,
+                City = from.City,
+                CountryCode = from.CountryIsoA2Code,
+                ZIPCode = from.PostCode,
+                Street = from.Street,
             };
             senderAddress.Validate();
 

--- a/ShippingProAPICollection/Provider/RequestShipmentBase.cs
+++ b/ShippingProAPICollection/Provider/RequestShipmentBase.cs
@@ -1,5 +1,6 @@
-﻿using JsonSubTypes;
+using JsonSubTypes;
 using Newtonsoft.Json;
+using ShippingProAPICollection.Models;
 using ShippingProAPICollection.Models.Error;
 using ShippingProAPICollection.Provider.DHL;
 using ShippingProAPICollection.Provider.DPD;
@@ -146,13 +147,18 @@ namespace ShippingProAPICollection.Provider
       /// <example>Ware auf den Briefkasten</example>
       public string? Note1 { get; set; }
 
+      /// <summary>
+      /// Individuelle Absenderadresse |
+      /// individual sender address
+      /// </summary>
+      public ShippingProAPIShipFromAddress? ShipFromAddress { get; set; }
 
       public virtual void Validate()
       {
          if ((Items?.Count ?? 0) <= 0) throw new ShipmentRequestLabelCountException(0);
          if (Country.Length != 2) throw new ShipmentRequestNoValidStringLengthException("Country", 2, 2);
 
-         foreach (var item in Items)
+         foreach (var item in Items!)
          {
             if (item.Weight > MaxPackageWeight) throw new ShipmentRequestWeightException(1, MaxPackageWeight, item.Weight);
          }

--- a/ShippingProAPICollection/Provider/TRANSOFLEX/TOFShipmentService.cs
+++ b/ShippingProAPICollection/Provider/TRANSOFLEX/TOFShipmentService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Memory;
 using Newtonsoft.Json;
 using RestSharp;
 using ShippingProAPICollection.Models;
@@ -20,13 +20,13 @@ namespace ShippingProAPICollection.Provider.TRANSOFLEX
     {
         private readonly IMemoryCache _cache;
         private TOFSettings providerSettings = null!;
-        private ShippingProAPIAccountSettings accountSettings = null!;
+        private ShippingProAPIShipFromAddress defaultShipFromAddress = null!;
         private Dictionary<string, TOFLoginStorage> loginStorage = new();
         private int sessionLifetime = 14;
 
-        public TOFShipmentService(ShippingProAPIAccountSettings accountSettings, TOFSettings providerSettings, IMemoryCache cache)
+        public TOFShipmentService(ShippingProAPIShipFromAddress defaultShipFromAddress, TOFSettings providerSettings, IMemoryCache cache)
         {
-            this.accountSettings = accountSettings;
+            this.defaultShipFromAddress = defaultShipFromAddress;
             this.providerSettings = providerSettings;
             this._cache = cache;
             LoadTOFLoginStorages();

--- a/ShippingProAPICollection/ShippingProAPICollectionService.cs
+++ b/ShippingProAPICollection/ShippingProAPICollectionService.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Caching.Memory;
 using ShippingProAPICollection.Models;
 using ShippingProAPICollection.Models.Entities;
 using ShippingProAPICollection.Provider;
@@ -21,24 +21,24 @@ namespace ShippingProAPICollection
 
             foreach (KeyValuePair<string, ProviderSettings> provider in providers)
             {
-                providerServices.Add(provider.Key, BuildProviderService(providerSettings.AccountSettings, provider.Value, _cache));
+                providerServices.Add(provider.Key, BuildProviderService(providerSettings.DefaultShipFromAddress, provider.Value, _cache));
             }
         }
 
-        private IShippingProviderService BuildProviderService(ShippingProAPIAccountSettings accountSettings, ProviderSettings settings, IMemoryCache _cache)
+        private IShippingProviderService BuildProviderService(ShippingProAPIShipFromAddress defaultShipFromAddress, ProviderSettings settings, IMemoryCache _cache)
         {
             switch (settings)
             {
                 case GLSSettings providerSettings:
-                    return new GLSShipmentService(accountSettings, providerSettings);
+                    return new GLSShipmentService(defaultShipFromAddress, providerSettings);
                 case DHLSettings providerSettings:
-                    return new DHLShipmentService(accountSettings, providerSettings);
+                    return new DHLShipmentService(defaultShipFromAddress, providerSettings);
                 case DPDSettings providerSettings:
-                    return new DPDShipmentService(accountSettings, providerSettings, _cache);
+                    return new DPDShipmentService(defaultShipFromAddress, providerSettings, _cache);
                 case TOFSettings providerSettings:
-                    return new TOFShipmentService(accountSettings, providerSettings, _cache);
+                    return new TOFShipmentService(defaultShipFromAddress, providerSettings, _cache);
                 case CustomProviderSettings providerSettings:
-                    return providerSettings.CreateProviderService(accountSettings, _cache);
+                    return providerSettings.CreateProviderService(defaultShipFromAddress, _cache);
                 default:  throw new Exception("provider not available");
             }
         }

--- a/ShippingProAPICollection/ShippingProAPICollectionSettings.cs
+++ b/ShippingProAPICollection/ShippingProAPICollectionSettings.cs
@@ -1,16 +1,16 @@
-﻿using ShippingProAPICollection.Models;
+using ShippingProAPICollection.Models;
 using ShippingProAPICollection.Provider;
 
 namespace ShippingProAPICollection
 {
     public class ShippingProAPICollectionSettings
     {
-        public ShippingProAPIAccountSettings AccountSettings { get; private set; }
+        public ShippingProAPIShipFromAddress DefaultShipFromAddress { get; private set; }
         private Dictionary<string, ProviderSettings> providerSettings { get; set; } = new Dictionary<string, ProviderSettings>();
 
-        public ShippingProAPICollectionSettings(ShippingProAPIAccountSettings accountSettings)
+        public ShippingProAPICollectionSettings(ShippingProAPIShipFromAddress defaultShipFromAddress)
         {
-            this.AccountSettings = accountSettings;
+            this.DefaultShipFromAddress = defaultShipFromAddress;
         }
 
         public Dictionary<string, ProviderSettings> GetProviders()
@@ -31,7 +31,7 @@ namespace ShippingProAPICollection
 
         public void OverrideSettings(ShippingProAPICollectionSettings newSettings)
         {
-            AccountSettings = newSettings.AccountSettings;
+            DefaultShipFromAddress = newSettings.DefaultShipFromAddress;
             providerSettings = newSettings.GetProviders();
         }
     }


### PR DESCRIPTION
- neue Möglichkeit, die Absenderadresse beim Erstellen eines Shipping-Labels individuell anzugeben
- README um ein vollständiges Beispiel mit ShipFromAddress-Überschreibung erweitert
- Refactoring (klarstellende Umbenennung des Models für die Absenderadresse, da "AccountSettings" nicht wirklich ein passender Name war - das sollte wohl ursprünglich bei Erstellung des Codes mal eine andere Funktion haben ;) )

Der Code wurde mit DHL und DPD getestet (Trans-o-flex und GLS nutzen wir nicht).